### PR TITLE
add KEC Computer Club

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Github Groups
 * GDG Birgunj - [github](https://github.com/gdgbirgunj)
 * HCOE Developers Circle - [github](https://github.com/hcoedevcircle)
 * Kathmandu Living Labs - [github](https://github.com/KathmanduLivingLabs) 
+* KEC Computer Club - [github](https://github.com/computerclubkec)
 * KEC Developers Circle - [github](https://github.com/kec-developers-circle)
 * KEC IT Club - [github](https://github.com/kec-it-club)
 * LOCUS IOE, Pulchowk - [github](https://github.com/locus-ioe)


### PR DESCRIPTION
This PR will add KEC Computer Club.

KEC Computer Club of Kantipur Engineering College, founded in 2013, empowers students to explore ideas and develop skills in the field of computers. Run by tech enthusiasts, the club exposes members to the latest advancements, offering guidance, workshops, and events that foster innovation and confidence. It’s a platform for engineering students to implement their ideas and grow in the rapidly evolving tech world.